### PR TITLE
Change gradle plugin version to 1.5.+

### DIFF
--- a/src/commands/setup/apply-gradle-plugin/__tests__/results/us.build.gradle
+++ b/src/commands/setup/apply-gradle-plugin/__tests__/results/us.build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.5.0"
+    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.5.+"
 }
 
 datadog {

--- a/src/commands/setup/apply-gradle-plugin/inject-plugin-in-build-gradle.ts
+++ b/src/commands/setup/apply-gradle-plugin/inject-plugin-in-build-gradle.ts
@@ -16,7 +16,7 @@ export const injectPluginInBuildGradle = async (
         hasAddedPluginAndConfiguration = true;
         const installationBlock = [
           `plugins {`,
-          `    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.5.0"`,
+          `    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.5.+"`,
           `}`,
           ``,
           `datadog {`,


### PR DESCRIPTION
### What and why?

Bump version to 1.5.+ so that users get the latest fixed

### How?

Change datadog gradle plugin version

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit)
