### PR TITLE
Fix double quotes escaping for RN versions below 69

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-react-native-wizard",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Setup wizard for Datadog React Native SDK",
   "repository": "https://github.com/DataDog/datadog-react-native-wizard",
   "license": "Apache-2.0",

--- a/src/commands/setup/change-xcode-build-phase/xcode-build-phase-editor/__tests__/results/rn68.project.pbxproj
+++ b/src/commands/setup/change-xcode-build-phase/xcode-build-phase-editor/__tests__/results/rn68.project.pbxproj
@@ -262,7 +262,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nexport NODE_BINARY=node\n# If the build runs from XCode, we cannot use yarn.\n# Therefore we need to check first which yarn command is appropriate\npackage_manager_test_command="bin" # both `yarn bin` and `npm bin` are valid commands\ntest_and_set_package_manager_bin()\n{\n  $(echo $1 $package_manager_test_command) && export PACKAGE_MANAGER_BIN=$1\n}\n \ntest_and_set_package_manager_bin "yarn" ||\ntest_and_set_package_manager_bin "/opt/homebrew/bin/node /opt/homebrew/bin/yarn" ||\necho "package manager not found"\n\nexport SOURCEMAP_FILE=./build/main.jsbundle.map\n$(echo $PACKAGE_MANAGER_BIN datadog-ci react-native xcode)\n";
+			shellScript = "set -e\n\nexport NODE_BINARY=node\n# If the build runs from XCode, we cannot use yarn.\n# Therefore we need to check first which yarn command is appropriate\npackage_manager_test_command=\"bin\" # both `yarn bin` and `npm bin` are valid commands\ntest_and_set_package_manager_bin()\n{\n  $(echo $1 $package_manager_test_command) && export PACKAGE_MANAGER_BIN=$1\n}\n \ntest_and_set_package_manager_bin \"yarn\" ||\ntest_and_set_package_manager_bin \"/opt/homebrew/bin/node /opt/homebrew/bin/yarn\" ||\necho \"package manager not found\"\n\nexport SOURCEMAP_FILE=./build/main.jsbundle.map\n$(echo $PACKAGE_MANAGER_BIN datadog-ci react-native xcode)\n";
 		};
 		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/src/commands/setup/change-xcode-build-phase/xcode-build-phase-editor/rn63/rn63-build-phase-editor.ts
+++ b/src/commands/setup/change-xcode-build-phase/xcode-build-phase-editor/rn63/rn63-build-phase-editor.ts
@@ -16,7 +16,7 @@ export class RN63BuildPhaseEditor extends XCodeBuildPhaseEditor {
     const [beforeScript, afterScript] = line.split(
       "../node_modules/react-native/scripts/react-native-xcode.sh"
     );
-    const datadogScript = `# If the build runs from XCode, we cannot use ${this.packageManager}.\\n# Therefore we need to check first which ${this.packageManager} command is appropriate\\npackage_manager_test_command=\"bin\" # both \`yarn bin\` and \`npm bin\` are valid commands\\ntest_and_set_package_manager_bin()\\n{\\n  $(echo $1 $package_manager_test_command) && export PACKAGE_MANAGER_BIN=$1\\n}\\n \\ntest_and_set_package_manager_bin \"${this.packageManager}\" ||\\ntest_and_set_package_manager_bin \"${this.nodeBin} ${this.packageManagerBin}\" ||\\necho \"package manager not found\"\\n\\nexport SOURCEMAP_FILE=./build/main.jsbundle.map\\n$(echo $PACKAGE_MANAGER_BIN datadog-ci react-native xcode)`;
+    const datadogScript = `# If the build runs from XCode, we cannot use ${this.packageManager}.\\n# Therefore we need to check first which ${this.packageManager} command is appropriate\\npackage_manager_test_command=\\"bin\\" # both \`yarn bin\` and \`npm bin\` are valid commands\\ntest_and_set_package_manager_bin()\\n{\\n  $(echo $1 $package_manager_test_command) && export PACKAGE_MANAGER_BIN=$1\\n}\\n \\ntest_and_set_package_manager_bin \\"${this.packageManager}\\" ||\\ntest_and_set_package_manager_bin \\"${this.nodeBin} ${this.packageManagerBin}\\" ||\\necho \\"package manager not found\\"\\n\\nexport SOURCEMAP_FILE=./build/main.jsbundle.map\\n$(echo $PACKAGE_MANAGER_BIN datadog-ci react-native xcode)`;
     return `${beforeScript}${datadogScript}${afterScript}`;
   };
 }


### PR DESCRIPTION
### What and why?

On React Native versions below 69, double quote escaping wasn't done properly, so the `project.pbxproj` file was broken after applying the bundle script change

### How?


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit)
