### PR TITLE
Fix template in build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ atomic, with a proper commit message.
 
 1. Create a branch named `release/x.y.z`
 1. Increment the version in package.json
-1. Run `yarn pack`, unpack the archive and check all relevant files are there (especially non ts files: `datadog-sourcemaps.sh.template`)
+1. Run `yarn pack`, unpack the archive and check all relevant files are there (especially non-TypeScript files: `datadog-sourcemaps.sh.template`)
 1. Run `yarn build`
 1. Run `yarn publish`
 1. Create a release with a tag on Github

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ atomic, with a proper commit message.
 
 1. Create a branch named `release/x.y.z`
 1. Increment the version in package.json
-1. Run `yarn pack`, unpack the archive and check all relevant files are there
+1. Run `yarn pack`, unpack the archive and check all relevant files are there (especially non ts files: `datadog-sourcemaps.sh.template`)
 1. Run `yarn build`
 1. Run `yarn publish`
 1. Create a release with a tag on Github

--- a/bin/postbuild.sh
+++ b/bin/postbuild.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cp src/commands/setup/change-xcode-build-phase/xcode-build-phase-editor/rn69/datadog-sourcemaps.sh.template dist/commands/setup/change-xcode-build-phase/xcode-build-phase-editor/rn69/datadog-sourcemaps.sh.template

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -rf dist/*",
     "check-licenses": "node bin/check-licenses.js",
     "launch": "ts-node --transpile-only src/cli.ts",
+    "postbuild": "./bin/postbuild.sh",
     "test": "jest"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-react-native-wizard",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Setup wizard for Datadog React Native SDK",
   "repository": "https://github.com/DataDog/datadog-react-native-wizard",
   "license": "Apache-2.0",

--- a/src/commands/setup/change-xcode-build-phase/xcode-build-phase-editor/rn69/rn69-build-phase-editor.ts
+++ b/src/commands/setup/change-xcode-build-phase/xcode-build-phase-editor/rn69/rn69-build-phase-editor.ts
@@ -1,3 +1,4 @@
+import { makeFileExecutable } from "../../../utils/make-file-executable";
 import { editFile } from "../../../utils/edit-file";
 import { XCodeBuildPhaseEditor } from "../xcode-build-phase-editor";
 
@@ -18,7 +19,7 @@ export class RN69BuildPhaseEditor extends XCodeBuildPhaseEditor {
   };
 
   private addDatadogScript = async () => {
-    return editFile(
+    await editFile(
       `${__dirname}/datadog-sourcemaps.sh.template`,
       this.datadogScriptLocation,
       (line: string) => {
@@ -28,6 +29,7 @@ export class RN69BuildPhaseEditor extends XCodeBuildPhaseEditor {
           .replace("{{packageManager}}", this.packageManager);
       }
     );
+    return makeFileExecutable(this.datadogScriptLocation);
   };
 
   protected getNewShellScript = (line: string) => {

--- a/src/commands/setup/utils/__tests__/fixtures/non-executable-scripts/script.sh
+++ b/src/commands/setup/utils/__tests__/fixtures/non-executable-scripts/script.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "executed"

--- a/src/commands/setup/utils/__tests__/make-file-executable.test.ts
+++ b/src/commands/setup/utils/__tests__/make-file-executable.test.ts
@@ -1,0 +1,55 @@
+import { exec } from "child_process";
+import { chmod } from "fs";
+import { makeFileExecutable } from "../make-file-executable";
+
+const execFile = (filePath: string) => {
+  return new Promise((resolve, reject) => {
+    exec(filePath, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+      }
+      if (stderr) {
+        reject(stderr);
+      }
+      resolve(stdout);
+    });
+  });
+};
+
+describe("makeFileExecutable", () => {
+  beforeEach(async () => {
+    // Making sure the fixture file is non executable
+    await new Promise<void>((resolve, reject) =>
+      chmod(
+        "src/commands/setup/utils/__tests__/fixtures/non-executable-scripts/script.sh",
+        0o644,
+        (error) => {
+          if (error) {
+            reject(error);
+          }
+          resolve();
+        }
+      )
+    );
+  });
+
+  it("turns a non-executable file into an executable one", async () => {
+    expect.assertions(2);
+
+    await expect(
+      execFile(
+        "src/commands/setup/utils/__tests__/fixtures/non-executable-scripts/script.sh"
+      )
+    ).rejects.toThrowError("Permission denied");
+
+    await makeFileExecutable(
+      "src/commands/setup/utils/__tests__/fixtures/non-executable-scripts/script.sh"
+    );
+
+    await expect(
+      execFile(
+        "src/commands/setup/utils/__tests__/fixtures/non-executable-scripts/script.sh"
+      )
+    ).resolves.toBe("executed\n");
+  });
+});

--- a/src/commands/setup/utils/make-file-executable.ts
+++ b/src/commands/setup/utils/make-file-executable.ts
@@ -1,0 +1,12 @@
+import { chmod } from "fs";
+
+export const makeFileExecutable = (absoluteFilePath: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    chmod(absoluteFilePath, 0o755, (err) => {
+      if (err) {
+        return reject(err);
+      }
+      resolve();
+    });
+  });
+};


### PR DESCRIPTION
### What and why?

The script template file was not included in the build, triggering an error for projects using react native over version 69.

### How?

Add a postbuild phase that fails if the template file has been moved.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit)
