### PR TITLE
Bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-react-native-wizard",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Setup wizard for Datadog React Native SDK",
   "repository": "https://github.com/DataDog/datadog-react-native-wizard",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

Bump package version to 0.1.0
This new version includes a new way of running datadog-ci from XCode

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit)
