### PR TITLE
Force datadog-ci to be compatible with new XCode template

### DIFF
--- a/src/commands/setup/__tests__/fixtures/project/package.json
+++ b/src/commands/setup/__tests__/fixtures/project/package.json
@@ -3,6 +3,6 @@
     "react-native": "0.69.0"
   },
   "devDependencies": {
-    "@datadog/datadog-ci": "1.13.3"
+    "@datadog/datadog-ci": "2.5.0"
   }
 }

--- a/src/commands/setup/add-dependencies/add-dependencies.ts
+++ b/src/commands/setup/add-dependencies/add-dependencies.ts
@@ -18,7 +18,7 @@ export const addDependencies = async (
   checkIsRNProject(absoluteProjectPath);
   const dependencyStatus = checkDependencyStatus(
     "@datadog/datadog-ci",
-    "1.13.3",
+    "2.5.0",
     { absoluteProjectPath: absoluteProjectPath }
   );
   if (dependencyStatus !== "OK") {


### PR DESCRIPTION
### What and why?

Increase the minimum version for datadog-ci, as we need to be on this version to make the new xcode build phases working.
(contains https://github.com/DataDog/datadog-ci/pull/781)


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit)
