### PR TITLE
Use version 1.+ for gradle plugin by default

### DIFF
--- a/src/commands/setup/apply-gradle-plugin/__tests__/results/us.build.gradle
+++ b/src/commands/setup/apply-gradle-plugin/__tests__/results/us.build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.5.+"
+    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.+"
 }
 
 datadog {

--- a/src/commands/setup/apply-gradle-plugin/__tests__/results/us.no-variant-loop.build.gradle
+++ b/src/commands/setup/apply-gradle-plugin/__tests__/results/us.no-variant-loop.build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.5.+"
+    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.+"
 }
 
 datadog {

--- a/src/commands/setup/apply-gradle-plugin/__tests__/results/us.rn72.build.gradle
+++ b/src/commands/setup/apply-gradle-plugin/__tests__/results/us.rn72.build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.5.+"
+    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.+"
 }
 
 datadog {

--- a/src/commands/setup/apply-gradle-plugin/inject-plugin-in-build-gradle.ts
+++ b/src/commands/setup/apply-gradle-plugin/inject-plugin-in-build-gradle.ts
@@ -38,7 +38,7 @@ export const injectPluginInBuildGradle = async (
         hasAddedPluginAndConfiguration = true;
         const installationBlock = [
           `plugins {`,
-          `    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.5.+"`,
+          `    id("com.datadoghq.dd-sdk-android-gradle-plugin") version "1.+"`,
           `}`,
           ``,
           `datadog {`,


### PR DESCRIPTION
### What and why?

Use version 1.+ of the gradle plugin by default.
This value will be written in the project `app/build.gradle` which can be modified at any moment by developers - so if a broken release happens, they will still be able to override the version.


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit)
